### PR TITLE
Kotlin tests

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+export JAVA_OPTS="-Xmx8g"
+export CLASSPATH="$PWD/kotlinx-coroutines-core-jvm-1.8.0-RC2.jar:$PWD/jna-5.13.0.jar:$PWD/okhttp-4.12.0.jar:$PWD/okio-jvm-3.7.0.jar"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+.idea
+*.jar

--- a/README.md
+++ b/README.md
@@ -17,6 +17,29 @@ All examples have two versions:
 - Callback based
 - Async wrapped (translated to callback)
 
+### Kotlin
+
+```sh
+brew install kotlin
+```
+
+#### Kotlin dependencies
+> [!IMPORTANT]  
+> To run tests in Kotlin you also need to download 
+> * [JNA](https://mvnrepository.com/artifact/net.java.dev.jna/jna) (currently tested under version `5.13.0`)
+> * [Coroutines-JVM](https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-core-jvm/1.8.0-RC2)
+> * [OkHttp](https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp/4.12.0) For network requests
+> * [Okio](https://mvnrepository.com/artifact/com.squareup.okio/okio/3.7.0) Transitive dependency for OkHttp
+> ``` sh
+> curl https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.13.0/jna-5.13.0.jar
+> curl https://repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.8.0-RC2/kotlinx-coroutines-core-jvm-1.8.0-RC2.jar
+> curl https://repo1.maven.org/maven2/com/squareup/okhttp3/okhttp/4.12.0/okhttp-4.12.0.jar
+> curl https://repo1.maven.org/maven2/com/squareup/okio/okio/3.7.0/okio-3.7.0.jar
+> ```
+
+### `direnv`
+Install [`direnv`](https://direnv.net/) in order to automatically load `CLASSPATH` and `JAVA_OPTS` in [`.envrc`](.envrc), so that you can run Kotlin bindgen tests from cli using the command in the bottom of this document - i.e. without having to export `CLASSPATH``.
+
 # Test
 
 Run test:

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,10 +1,17 @@
 #[cfg(test)]
 mod tests {
-    uniffi::build_foreign_language_testcases!(
-        "tests/test_networking.swift",
-        "tests/test_networking.kts"
-    );
-    uniffi::build_foreign_language_testcases!("tests/test_async_stream_from_rust.swift",);
-    uniffi::build_foreign_language_testcases!("tests/test_async_stream_from_swift.swift",);
-    uniffi::build_foreign_language_testcases!("tests/test_file_io.swift",);
+     uniffi::build_foreign_language_testcases!(
+         "tests/test_networking.swift",
+         "tests/test_networking.kts"
+     );
+     uniffi::build_foreign_language_testcases!(
+         "tests/test_async_stream_from_rust.swift",
+     );
+     uniffi::build_foreign_language_testcases!(
+         "tests/test_async_stream_from_swift.swift",
+         "tests/test_async_stream_from_kotlin.kts",
+     );
+     uniffi::build_foreign_language_testcases!(
+         "tests/test_file_io.swift",
+     );
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,6 +1,9 @@
 #[cfg(test)]
 mod tests {
-    uniffi::build_foreign_language_testcases!("tests/test_networking.swift",);
+    uniffi::build_foreign_language_testcases!(
+        "tests/test_networking.swift",
+        "tests/test_networking.kts"
+    );
     uniffi::build_foreign_language_testcases!("tests/test_async_stream_from_rust.swift",);
     uniffi::build_foreign_language_testcases!("tests/test_async_stream_from_swift.swift",);
     uniffi::build_foreign_language_testcases!("tests/test_file_io.swift",);

--- a/tests/test_networking.kts
+++ b/tests/test_networking.kts
@@ -1,0 +1,103 @@
+import uniffi.ffibre.*
+import kotlinx.coroutines.*
+import okhttp3.*
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Headers.Companion.toHeaders
+
+object KotlinNetworkAntenna: FfiNetworkingExecutor {
+    private val client = OkHttpClient()
+
+    override fun executeNetworkingRequest(request: FfiNetworkingRequest, listenerRustSide: FfiNetworkingOutcomeListener) {
+        val outcome = runCatching {
+            val contentType = request.headers["Content-Type"] ?: "application/json; charset=utf-8"
+
+            val requestBody = RequestBody.create(
+                contentType.toMediaType(),
+                request.body
+            )
+            val request = Request.Builder()
+                .url(url = request.url)
+                .headers(request.headers.toHeaders())
+                .method(method = request.method, body = requestBody)
+                .build()
+
+            client.newCall(request).execute()
+        }.fold(
+            onSuccess = { response ->
+                if (response.isSuccessful) {
+                    FfiNetworkingOutcome.Success(
+                        value = FfiNetworkingResponse(
+                            statusCode = response.code.toUShort(),
+                            body = response.body?.bytes() ?: byteArrayOf()
+                        )
+                    )
+                } else {
+                    FfiNetworkingOutcome.Failure(
+                        error = FfiNetworkingError.RequestFailed(
+                            statusCode = response.code.toUShort(),
+                            urlSessionUnderlyingError = null,
+                            errorMessageFromGateway = response.body?.string()
+                        )
+                    )
+                }
+            },
+            onFailure = { error ->
+                FfiNetworkingOutcome.Failure(
+                    error = FfiNetworkingError.RequestFailed(
+                        statusCode = null,
+                        urlSessionUnderlyingError = error.toString(),
+                        errorMessageFromGateway = null
+                    )
+                )
+            }
+        )
+
+        listenerRustSide.notifyOutcome(result = outcome)
+    }
+}
+
+suspend fun testBalance(address: String) = runCatching {
+    println("🛜 ┌ Test Balance")
+    println("🛜 ┝ Request for $address")
+    val client = GatewayClient(networkAntenna = KotlinNetworkAntenna)
+    client.getXrdBalanceOfAccount(address = address)
+}.onSuccess { balance ->
+    println("🛜 ┝ $balance ")
+    println("🛜 └ ✅ ")
+}.onFailure { error ->
+    println("🛜 └ ❌  ${error}")
+}
+
+suspend fun testLatestTransactions() = runCatching {
+    println("🛜 ┌ Test Latest Transactions")
+    val client = GatewayClient(networkAntenna = KotlinNetworkAntenna)
+    client.getLatestTransactions()
+}.onSuccess { transactions ->
+     println("${transactions.joinToString(prefix = "🛜 ┝ ", separator = "\n🛜 ┝ ")}")
+     println("🛜 └ ✅ ")
+}.onFailure { error ->
+     println("🛜 └ ❌  ${error}")
+}
+
+suspend fun testLatestTransaction() = runCatching {
+    println("🛜 ┌ Test Latest Transaction or Panic ")
+    val client = GatewayClient(networkAntenna = KotlinNetworkAntenna)
+    client.getLatestTransactionsOrPanic()
+}.onSuccess { transaction ->
+     println("🛜 ┝ $transaction")
+     println("🛜 └ ✅ ")
+}.onFailure { error ->
+     println("🛜 └ ❌  ${error}")
+}
+
+fun test() = runBlocking {
+    println("🛜 🚀 Kotlin 'test_networking' start")
+
+    testBalance(address = "account_rdx16xlfcpp0vf7e3gqnswv8j9k58n6rjccu58vvspmdva22kf3aplease")
+    testLatestTransactions()
+    testLatestTransaction()
+
+    println("🛜 🏁 Kotlin 'test_networking' done")
+}
+
+test()


### PR DESCRIPTION
Implement tests network requests. 

Verified using `OkHttp` which is a library that `Retrofit` uses in order to make the network requests. It is widely used in the android world.

Some things to discuss:
1. `FfiNetworkingError.RequestFailed` seems to me that could be divided in two
    * One indicating that request was sent but there was an error server side (with status code not optional)
        * In this case the object may look like this
           ```
           pub struct RequestFailed {
              pub status_code: u16,
          
              /// Can be empty.
              pub errorBody: Vec<u8>, // Better let Rust deserialise the error body, as it does for the success body
          }
           ``` 
    * One indicating that an error occurred client side. (No internet connection). In this error we can pass a string representation of the client's exception.
2. File I/O is still pending....